### PR TITLE
Bug fix for password not being required when used in tandem with the …

### DIFF
--- a/lib/devise/models/magic_link_authenticatable.rb
+++ b/lib/devise/models/magic_link_authenticatable.rb
@@ -6,26 +6,29 @@ module Devise
     module MagicLinkAuthenticatable
       extend ActiveSupport::Concern
 
-      # Models using the :database_authenticatable strategy will already
-      # have #password_required? and #password defined - we will defer
-      # to those methods if they already exist so that people can use
-      # both strategies together. Otherwise, for :magic_link_authenticatable-
-      # only users, we define them in order to disable password validations:
+      included do
+        # Models using the :database_authenticatable strategy will already
+        # have #password defined and models using the :validatable strategy
+        # will already have #password_required? defined - we will defer
+        # to those methods if they already exist so that people can use
+        # both strategies together. Otherwise, for :magic_link_authenticatable-
+        # only users, we define them in order to disable password validations:
 
-      unless instance_methods.include?(:password_required?)
-        def password_required?
-          false
+        unless instance_methods.include?(:password_required?)
+          def password_required?
+            false
+          end
         end
-      end
 
-      unless instance_methods.include?(:password)
-        # Not having a #password method breaks the :validatable module
-        #
-        # NOTE I proposed a change to Devise to fix this:
-        # https://github.com/heartcombo/devise/issues/5346#issuecomment-822022834
-        # As of yet it hasn't been accepted due to unknowns of the legacy code's purpose
-        def password
-          nil
+        unless instance_methods.include?(:password)
+          # Not having a #password method breaks the :validatable module
+          #
+          # NOTE I proposed a change to Devise to fix this:
+          # https://github.com/heartcombo/devise/issues/5346#issuecomment-822022834
+          # As of yet it hasn't been accepted due to unknowns of the legacy code's purpose
+          def password
+            nil
+          end
         end
       end
 


### PR DESCRIPTION
…database_authenticatable and validatable modules.

This fix properly ensures that the  and  methods are not redefined by  if they already exist in the model. The check for the existing methods via  must be done in the context of the class the module is being included into and not in the module itself.